### PR TITLE
Use .env more for additional flexibility

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,12 @@
-# This is the vpn machine public IP or domain name
-#MASTER="myvpn.com"
-MASTER="13.49.222.49"
+# Set variables here for the Docker Compose file
+# Timezone you are in - find yours here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+TIMEZONE="Europe/London"
+
+# Set your public IP address here - find yours by running `curl https://ipv4.icanhazip.com/` in the terminal
+PUBLIC_IP="1.1.1.1"
+
+# Set the password used to access the Wireguard UI here - generate a strong one here: https://1password.com/password-generator/
 WG_PASSWORD="passwd"
+
+# Set the password used to access the Pi-Hole UI here - generate a strong one hre: https://1password.com/password-generator/
 PIHOLE_PASSWORD="passwd"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To begin using WireHole, clone the repository and start the containers:
 #!/bin/bash
 
 # Clone the WireHole repository from GitHub
-git clone https://github.com/m-karakus/wirehole.git
+git clone https://github.com/raspberrycoulis/wirehole.git
 
 # Change directory to the cloned repository
 cd wirehole
@@ -75,7 +75,7 @@ nano .env  # Or use any text editor of your choice to edit the .env file
 docker compose up
 ```
 
-Remember to set secure passwords for  `WG_PASSWORD`, and `PIHOLE_PASSWORD` in your `.env` file.
+Remember to set secure passwords for  `WG_PASSWORD`, and `PIHOLE_PASSWORD` as well as updating your `TIMEZONE` and setting your `PUBLIC_IP` address in your `.env` file.
 
 
 
@@ -89,7 +89,8 @@ The `.env` file contains a series of environment variables that are essential fo
 
 *Update the `.env` file.*
 
-- `MASTER` is your public ip or domain.
+- `TIMEZONE` is your timezone - i.e. `Europe/London`
+- `PUBLIC_IP` is your public ip or domain.
 - `WG_PASSWORD` is wireguard UI password.
 - `PIHOLE_PASSWORD` pihole UI password.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To begin using WireHole, clone the repository and start the containers:
 #!/bin/bash
 
 # Clone the WireHole repository from GitHub
-git clone https://github.com/raspberrycoulis/wirehole.git
+git clone https://github.com/m-karakus/wirehole.git
 
 # Change directory to the cloned repository
 cd wirehole

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,8 @@ services:
       - pihole
     environment:
       # ⚠️ Required:
-      # Change this to your host's public address
-      - WG_HOST=${MASTER}
+      # Set this in the .env file
+      - WG_HOST=${PUBLIC_IP}
 
       # Optional:
       - PASSWORD=${WG_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 127.0.0.1
       - 10.2.0.200 # Points to unbound
     environment:
-      TZ: "Europe/Istanbul"
+      TZ: ${TIMEZONE} # Set in the .env file
       WEBPASSWORD: ${PIHOLE_PASSWORD} # Blank password - Can be whatever you want.
       ServerIP: 10.2.0.100 # Internal IP of pihole
       DNS1: 10.2.0.200 # Unbound IP


### PR DESCRIPTION
Rather than set some options in the `docker-compose.yml` file, set them using the `.env` file instead. I've tweaked this to set the timezone via `.env` and also made the `.env` names a bit more logical for some. Should help!